### PR TITLE
Adding setting of max-width inside ThrottleUpdates

### DIFF
--- a/stickyHeaders.js
+++ b/stickyHeaders.js
@@ -187,6 +187,8 @@ function stickyHeaders() {
 			for(var i=0; i < stickyChildren.length; i++){
 				jQuery(stickyChildren[i]).css("min-width",   stickyChildrenWidths[i]);
 				jQuery(firstRowChildren[i]).css("min-width", firstRowChildrenWidths[i]);
+				jQuery(stickyChildren[i]).css("max-width", stickyChildrenWidths[i]);
+                		jQuery(firstRowChildren[i]).css("max-width", firstRowChildrenWidths[i]);
 			};
 			this.sticky.css("position", this.sticky.hasClass("stickyHeader") ? "fixed" : "static")
 		});


### PR DESCRIPTION
Current version bug: If the list is too large (Too many columns for example), when you scroll-x at the end of the list, the StickyHeader will not stay aligned with the list. This change worked for me to solve that problem.